### PR TITLE
[#23] feat : 회원가입 시 Exception을 메시지화 할 Response 설계

### DIFF
--- a/src/main/java/com/aorri2/goodsforyou/common/domain/ErrorResult.java
+++ b/src/main/java/com/aorri2/goodsforyou/common/domain/ErrorResult.java
@@ -1,0 +1,31 @@
+package com.aorri2.goodsforyou.common.domain;
+
+/**
+ * 사용자한테 전달 될 에러 응답 형식
+ * 해당 에러의 에러 코드와, 에러 메시지를 넘겨주는 방식
+ * kakao REST API 레퍼런스 참고했습니다
+ */
+public class ErrorResult {
+
+	/**
+	 * 'USER-001'과 같이 에러 코드를 나타내는 변수
+	 */
+	private final String code;
+	/**
+	 * 발생한 에러의 원인에 대한 참고 정보로 사용될 수 있는 메시지
+	 */
+	private final String message;
+
+	public ErrorResult(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}


### PR DESCRIPTION
## 작업 내용

- 회원가입 시 Exception을 메시지화 할 Response를 설계했습니다.

### Error Code

Error CodeName | Description | Solution | HTTP 상태 코드
-- | -- | -- | --
USER001 | 필수 값이 포함되지 않은 경우나, 값의 형식이 일치하지 않는 경우 | 요청에 포함된 파라미터를 확인한 후 재요청합니다. | 400

에러 코드는 위와 같은 형식으로 구성하려 합니다. 다른 에러 코드는 프로젝트를 진행하면서 위키의 ErrorCode 란에 추가하려 합니다.

### Error Code Json Example

```
{
  "code":"USER-001",
  "message":"패스워드는 최소 8 글자 이상이여야 합니다."
}
```
